### PR TITLE
Finish pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,6 @@ jobs:
       - sdkms-cli/install
       - sdkms-cli/authenticate:
           api-endpoint: "https://sdkms.fortanix.com"
-          api-key: >
-              "YzA3ZDM2MDctODljMC00MmNlLTliMDktMDlhMGVkODVhM2
-              FkOmpib09mSUlzM3ZDZWZmY3ZYbV9OZXc="
       - sdkms-cli/get-secret:
           api-endpoint: "https://sdkms.fortanix.com"
           secret-name: "ci-test-secret"
@@ -91,62 +88,61 @@ workflows:
             branches:
               only: master
 
-  integration_tests-prod_deploy:
+  # this `integration-tests_prod-release` workflow will ignore commits
+  # it is only triggered by git tags, which are created in the job above
+  integration-tests_prod-release:
     jobs:
-      # triggered by non-master branch commits
       - gettest:
           name: gettest-dev
           filters: *integration-dev_filters
+      - gettest:
+          name: gettest-master
+          filters: *integration-master_filters
+      # - your integration test jobs go here
+      # - you will want to call each integration testing job twice,
+      # - each under a different name:
+      # - once, for integration tests triggered by non-master-branch commits
+      # - and again, for tests triggered by commits to master
+      # - only commits to master should potentially trigger a prod release
 
-  # this `integration-tests_prod-release` workflow will ignore commits
-  # it is only triggered by git tags, which are created in the job above
-  # integration-tests_prod-release:
-  #   jobs:
-  #     # - your integration test jobs go here
-  #     # - you will want to call each integration testing job twice,
-  #     # - each under a different name:
-  #     # - once, for integration tests triggered by non-master-branch commits
-  #     # - and again, for tests triggered by commits to master
-  #     # - only commits to master should potentially trigger a prod release
+      # patch, minor, or major publishing
+      - orb-tools/dev-promote-prod:
+          name: dev-promote-patch
+          orb-name: circleci/orb-tools
+          ssh-fingerprints: d5:3f:13:e2:db:51:c3:65:60:87:26:e2:08:98:9e:67
+          cleanup-tags: true
+          requires:
+            - gettest-master
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /master-patch.*/
 
-  #     # patch, minor, or major publishing
-  #     - orb-tools/dev-promote-prod:
-  #         name: dev-promote-patch
-  #         orb-name: circleci/orb-tools
-  #         ssh-fingerprints: # your SSH key fingerprint
-  #         cleanup-tags: true
-  #         requires:
-  #           # - your integration testing jobs go here
-  #         filters:
-  #           branches:
-  #             ignore: /.*/
-  #           tags:
-  #             only: /master-patch.*/
+      - orb-tools/dev-promote-prod:
+          name: dev-promote-minor
+          release: minor
+          orb-name: circleci/orb-tools
+          ssh-fingerprints: d5:3f:13:e2:db:51:c3:65:60:87:26:e2:08:98:9e:67
+          cleanup-tags: true
+          requires:
+            - gettest-master
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /master-minor.*/
 
-  #     - orb-tools/dev-promote-prod:
-  #         name: dev-promote-minor
-  #         release: minor
-  #         orb-name: circleci/orb-tools
-  #         ssh-fingerprints: # your SSH key fingerprint
-  #         cleanup-tags: true
-  #         requires:
-  #           # - your integration testing jobs go here
-  #         filters:
-  #           branches:
-  #             ignore: /.*/
-  #           tags:
-  #             only: /master-minor.*/
-
-  #     - orb-tools/dev-promote-prod:
-  #         name: dev-promote-major
-  #         release: major
-  #         orb-name: circleci/orb-tools
-  #         ssh-fingerprints: # your SSH key fingerprint
-  #         cleanup-tags: true
-  #         requires:
-  #           # - your integration testing jobs go here
-  #         filters:
-  #           branches:
-  #             ignore: /.*/
-  #           tags:
-  #             only: /master-major.*/
+      - orb-tools/dev-promote-prod:
+          name: dev-promote-major
+          release: major
+          orb-name: circleci/orb-tools
+          ssh-fingerprints: d5:3f:13:e2:db:51:c3:65:60:87:26:e2:08:98:9e:67
+          cleanup-tags: true
+          requires:
+            - gettest-master
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /master-major.*/

--- a/src/commands/authenticate.yml
+++ b/src/commands/authenticate.yml
@@ -10,11 +10,12 @@ parameters:
     default: "https://sdkms.fortanix.com"
     description: "SDKMS API Endpoint"
   api-key:
-    type: string
+    type: env_var_name
+    default: "SDKMS_API_KEY"
     description: "SDKMS API Key"
 steps:
   - run:
       name: Authenticate as an app to SDKMS
       command: |
           sdkms-cli --api-endpoint <<parameters.api-endpoint>> app-login\
-           --api-key <<parameters.api-key>>
+           --api-key $<<parameters.api-key>>

--- a/src/commands/get-secret.yml
+++ b/src/commands/get-secret.yml
@@ -31,7 +31,7 @@ steps:
           else
             rm -f /tmp/export_value
             echo "export SDKMS_SECRET_VALUE=$(cat $SECRET_VALUE_FILE)"\
-             >> /tmp/export_value
+             />>> /tmp/export_value
             source /tmp/export_value
             rm -f /tmp/export_value
           fi


### PR DESCRIPTION
Hello,

I have removed the API key string and replaced it with a required env var, "$SDKMS_API_KEY" by default.

The rest of the pipeline was uncommented and filled out so, if done correctly, should now run your "gettest" job before producing a new production version.

You will not need to manually create a production version. Assuming everything is working, once the branch is merged into master you should see the "integration-tests_prod-release" workflow run with the "integration-master_filters" filters, triggering the production deploy

Two notes:

- Examples: Rename example.yml to the name of the example you would like to show and demonstrate how to utilize one of the commands in the orb. Consider adding examples for both jobs and perhaps the store-secret and get-secret commands.

- The orb will need to be re-tested after these changes. within Get-secrets I noticed a ">>" which was showing as an error in my linter. I believe this may interfere with the "<<>>" from parameters but was having some trouble finding that documentation. If this worked previously with no issue then we could remove this. Otherwise I believe this should resolve the issue.